### PR TITLE
Stdin/out+foo.service() patch

### DIFF
--- a/bin/ngmin
+++ b/bin/ngmin
@@ -2,31 +2,36 @@
 
 var program = require('commander'),
   fs = require('fs'),
+  argv = require('optimist').argv,
   ngmin = require('../main');
 
 program
   .version('0.0.4')
-  .usage('<infile> <outfile>')
-  .parse(process.argv);
+  .usage('<infiles or stdin> -o <outfile or stdout>');
 
-if (program.args.length < 2) {
-  console.error('ngmin called with too few arguments');
-  process.exit(1);
-}
+var infiles = argv._;
+var outfile = argv.o > 1 ? argv.o : null;
 
-var infile = program.args[0];
-var outfile = program.args[1];
-
-try {
-  var content = fs.readFileSync(infile, 'utf-8');
-} catch (e) {
-  console.error('Error opening: ' + infile);
-  process.exit(1);
+var content = "";
+if(infiles.length) {
+  for(var i = 0, l = infiles.length; i < l; i++) {
+     var infile = infiles[i];
+     try {
+       content += fs.readFileSync(infile, 'utf-8') + ";"
+     } catch (e) {
+       console.error('Error opening: ' + infile);
+       process.exit(1);
+     }
+  }
+} else {
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+  content = fs.readSync(process.stdin.fd, 100000).shift();
 }
 var generatedCode = ngmin.annotate(content);
 
 try {
-  fs.writeFileSync(outfile, generatedCode);
+  outfile ? fs.writeFileSync(outfile, generatedCode) : fs.writeSync(process.stdout.fd, generatedCode);
 } catch (e) {
   console.error('Error writing to: ' + outfile);
   process.exit(1);

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 
 var esprima = require('esprima'),
   escodegen = require('escodegen'),
-  signature = require('./signature'),
+  signatures = require('./signature'),
   deepCompare = require('./util/deep-compare');
 
 
@@ -10,27 +10,29 @@ var esprima = require('esprima'),
  */
 var annotateAST = function (syntax) {
 
-  // locate angular modules and references
-  syntax.body
+    // locate angular modules and references
+    syntax.body
 
-  // rewrite each matching chunk
-  syntax.body.forEach(function (chunk) {
-    var originalFn, newParam;
-    if (deepCompare(chunk, signature)) {
-      originalFn = chunk.expression.arguments[1];
-      newParam = chunk.expression.arguments[1] = {
-        type: 'ArrayExpression',
-        elements: []
-      };
-      originalFn.params.forEach(function (param) {
-        newParam.elements.push({
-          "type": "Literal",
-          "value": param.name
+    // rewrite each matching chunk
+    syntax.body.forEach(function (chunk) {
+        var originalFn, newParam;
+        signatures.forEach(function(signature) {
+            if (deepCompare(chunk, signature)) {
+                originalFn = chunk.expression.arguments[1];
+                newParam = chunk.expression.arguments[1] = {
+                    type: 'ArrayExpression',
+                    elements: []
+                };
+                originalFn.params.forEach(function (param) {
+                    newParam.elements.push({
+                        "type": "Literal",
+                        "value": param.name
+                    });
+                });
+                newParam.elements.push(originalFn);
+            }
         });
-      });
-      newParam.elements.push(originalFn);
-    }
-  });
+    });
 };
 
 
@@ -46,9 +48,9 @@ var annotate = exports.annotate = function (inputCode) {
 
   var generatedCode = escodegen.generate(syntax, {
     format: {
-      indent: {
-        style: '  '
-      }
+        indent: {
+            style: '    '
+        }
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "escodegen": "~0.0.15",
     "esprima": "~1.0.2",
+    "optimist": "~0.3.5",
     "commander": "~1.1.1"
   },
   "devDependencies": {

--- a/signature.js
+++ b/signature.js
@@ -1,41 +1,73 @@
-
-// look for this structure in the AST
-var signature = module.exports = {
-  "type": "ExpressionStatement",
-  "expression": {
-    "type": "CallExpression",
-    "callee": {
-      "type": "MemberExpression",
-      "object": {
-        "type": "CallExpression",
-        "callee": {
-          "type": "MemberExpression",
-          "object": {
-            "type": "Identifier",
-            "name": "angular"
-          },
-          "property": {
-            "type": "Identifier",
-            "name": "module"
-          }
+module.exports = [
+    // variable.service(...)
+    {
+        "type": "ExpressionStatement",
+        "expression": {
+            "type": "CallExpression",
+            "callee": {
+                "type": "MemberExpression",
+                "object": {
+                    "type": "Identifier",
+                    "name": /^.*$/
+                },
+                "property": {
+                    "type": "Identifier",
+                    "name": /^(controller|directive|filter|service|factory|decorator|config|provider)$/
+                }
+            },
+            "arguments": [
+                {
+                    "type": "Literal"
+                },
+                {
+                    "type": "FunctionExpression",
+                    "body": {
+                        "type": "BlockStatement",
+                        "body": []
+                    }
+                }
+            ]
         }
-      },
-      "property": {
-        "type": "Identifier",
-        "name": /^(controller|directive|filter|service|factory|decorator|config|provider)$/
-      }
     },
-    "arguments": [
-      {
-        "type": "Literal"
-      },
-      {
-        "type": "FunctionExpression",
-        "body": {
-          "type": "BlockStatement",
-          "body": []
+    // angular.module(...).service(...)
+    {
+        "type": "ExpressionStatement",
+        "expression": {
+            "type": "CallExpression",
+            "callee": {
+                "type": "MemberExpression",
+                "object": {
+                    "type": "CallExpression",
+                    "callee": {
+                        "type": "MemberExpression",
+                        "object": {
+                            "type": "Identifier",
+                            "name": "angular"
+                        },
+                        "property": {
+                            "type": "Identifier",
+                            "name": "module"
+                        }
+                    }
+                },
+                "property": {
+                    "type": "Identifier",
+                    "name": /^(controller|directive|filter|service|factory|decorator|config|provider)$/
+                }
+            },
+            "arguments": [
+                {
+                    "type": "Literal"
+                },
+                {
+                    "type": "FunctionExpression",
+                    "body": {
+                        "type": "BlockStatement",
+                        "body": []
+                    }
+                }
+            ]
         }
-      }
-    ]
-  }
-};
+    }
+];
+


### PR DESCRIPTION
Now handles stdin/stdout:
  ngmin f1 f2 -o out 
  cat *.js | ngmin | cat >out.js
Doesn't require angular.module().service(...) anymore, can also be fooApp.service(...)

Thanks for this neat tool. 

In the normal unix tradition, I added the option to add multiple files (output is now with -o) and also to process stdin and stdout.

Also, since a lot of projects don't use angular.module('foo',[]).service in each file, I changed the handling to foo.service(..)
