### PR TITLE
Fix annotation on directive controllers of annotated directives

### DIFF
--- a/lib/annotate-ast.js
+++ b/lib/annotate-ast.js
@@ -65,13 +65,7 @@ var annotateAST = module.exports = function (syntax) {
         "type": "Identifier",
         "name": "directive"
       }
-    },
-    "arguments": [
-      {},
-      {
-        "type": "FunctionExpression"
-      }
-    ]
+    }
   }], function (directiveChunk) {
     deepApply(directiveChunk, [{
       "type": "ReturnStatement",

--- a/test/directive.js
+++ b/test/directive.js
@@ -44,4 +44,27 @@ describe('annotate', function () {
     }));
   });
 
+  it('should annotate directive controllers of annotated directives', function () {
+    var annotated = annotate(function () {
+      angular.module('myMod', []).
+        directive('myDir', function ($window) {
+          return {
+            controller: function ($scope) { $scope.test = true; }
+          };
+        });
+    });
+
+    annotated.should.equal(stringifyFunctionBody(function () {
+      angular.module('myMod', []).
+        directive('myDir', ['$window', function ($window) {
+          return {
+            controller: [
+              '$scope',
+              function ($scope) { $scope.test = true; }
+            ]
+          };
+        }]);
+    }));
+  });
+
 });


### PR DESCRIPTION
Currently, directives that require (or have) annotations do not get their controllers annotated. For example, this directive's `controller` will not be correctly annotated.

``` javascript
mod.directive('MyDirective', ['$window', function($window) {
  return {
    controller: function($scope) { ... }
  };
}])
```

This pull request removes the arguments check on `mod.directive`, assuming that a call to `directive` on an `ngModule` will be enough to verify that portion of the AST walk.
