### PR TITLE
Annotate `this.$get` function in providers

### DIFF
--- a/lib/annotate-ast.js
+++ b/lib/annotate-ast.js
@@ -5,6 +5,27 @@ var deepApply = require('./deep-apply');
 // look for `modRef.fn` in AST
 var signatures = require('../signatures/simple');
 
+var annotateInjectables = function(originalFn) {
+  // if there's nothing to inject, don't annotate
+  if (originalFn.params.length === 0) {
+    return originalFn;
+  }
+
+  var newParam = {
+    type: 'ArrayExpression',
+    elements: []
+  };
+
+  originalFn.params.forEach(function (param) {
+    newParam.elements.push({
+      "type": "Literal",
+      "value": param.name
+    });
+  });
+  newParam.elements.push(originalFn);
+  return newParam;
+};
+
 
 /*
  * Modifies AST to add annotations to injectable AngularJS module methods
@@ -30,25 +51,7 @@ var annotateAST = module.exports = function (syntax) {
     if (type === 'constant' || type === 'value') {
       return;
     }
-    originalFn = chunk.arguments[argIndex];
-
-    // if there's nothing to inject, don't annotate
-    if (originalFn.params.length === 0) {
-      return;
-    }
-
-    newParam = chunk.arguments[argIndex] = {
-      type: 'ArrayExpression',
-      elements: []
-    };
-
-    originalFn.params.forEach(function (param) {
-      newParam.elements.push({
-        "type": "Literal",
-        "value": param.name
-      });
-    });
-    newParam.elements.push(originalFn);
+    chunk.arguments[argIndex] = annotateInjectables(chunk.arguments[argIndex]);
   });
 
 
@@ -83,27 +86,46 @@ var annotateAST = module.exports = function (syntax) {
           "type": "FunctionExpression"
         }
       }], function (controllerChunk) {
-        var originalFn = controllerChunk.value;
-
-
-        // if there's nothing to inject, don't annotate
-        if (originalFn.params.length === 0) {
-          return;
-        }
-
-        var newParam = controllerChunk.value = {
-          type: 'ArrayExpression',
-          elements: []
-        };
-
-        originalFn.params.forEach(function (param) {
-          newParam.elements.push({
-            "type": "Literal",
-            "value": param.name
-          });
-        });
-        newParam.elements.push(originalFn);
+        controllerChunk.value = annotateInjectables(controllerChunk.value);
       });
+    });
+  });
+
+  // PDO annotations
+
+  deepApply(syntax, [{
+    "type": "CallExpression",
+    "callee": {
+      "type": "MemberExpression",
+      "object": {
+        "ngModule": true
+      },
+      "property": {
+        "type": "Identifier",
+        "name": "provider"
+      }
+    }
+  }], function (providerChunk) {
+    deepApply(providerChunk, [{
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "AssignmentExpression",
+        "left": {
+          "type": "MemberExpression",
+          "object": {
+            "type": "ThisExpression"
+          },
+          "property": {
+            "type": "Identifier",
+            "name": "$get"
+          }
+        },
+        "right": {
+          "type": "FunctionExpression"
+        }
+      }
+    }], function(pdoChunk) {
+      pdoChunk.expression.right = annotateInjectables(pdoChunk.expression.right);
     });
   });
 

--- a/lib/annotate-ast.js
+++ b/lib/annotate-ast.js
@@ -91,7 +91,42 @@ var annotateAST = module.exports = function (syntax) {
     });
   });
 
-  // PDO annotations
+  // PDO annotations - defined by object
+
+  deepApply(syntax, [{
+    "type": "CallExpression",
+    "callee": {
+      "type": "MemberExpression",
+      "object": {
+        "ngModule": true
+      },
+      "property": {
+        "type": "Identifier",
+        "name": "provider"
+      }
+    }
+  }], function (providerChunk) {
+    deepApply(providerChunk, [{
+      "type": "ObjectExpression"
+    }], function(objectChunk) {
+      objectChunk.properties.forEach(function(property) {
+        deepApply(property, [{
+          "type": "Property",
+          "key": {
+            "type": "Identifier",
+            "name": "$get"
+          },
+          "value": {
+            "type": "FunctionExpression"
+          }
+        }], function(propertyChunk) {
+          propertyChunk.value = annotateInjectables(propertyChunk.value);
+        });
+      });
+    });
+  });
+
+  // PDO annotations - defined by function
 
   deepApply(syntax, [{
     "type": "CallExpression",

--- a/test/simple.js
+++ b/test/simple.js
@@ -157,7 +157,7 @@ describe('annotate', function () {
   });
 
 
-  it('should annotate providers', function () {
+  it('should annotate providers defined by functions', function () {
     var annotated = annotate(function () {
       angular.module('myMod', []).
         provider('myService', function (dep) {
@@ -172,6 +172,23 @@ describe('annotate', function () {
           this.$get = ['otherDep', function(otherDep) {}];
         }
       ]);
+    }));
+  });
+
+
+  it('should annotate providers defined by objects', function () {
+    var annotated = annotate(function () {
+      angular.module('myMod', []).
+        provider('myService', {
+          $get: function(otherDep) {}
+        })
+    });
+
+    annotated.should.equal(stringifyFunctionBody(function () {
+      angular.module('myMod', []).
+        provider('myService', {
+          $get: ['otherDep', function(otherDep) {}]
+        });
     }));
   });
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -160,13 +160,16 @@ describe('annotate', function () {
   it('should annotate providers', function () {
     var annotated = annotate(function () {
       angular.module('myMod', []).
-        provider('myService', function (dep) {});
+        provider('myService', function (dep) {
+          this.$get = function(otherDep) {};
+        });
     });
 
     annotated.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).provider('myService', [
         'dep',
         function (dep) {
+          this.$get = ['otherDep', function(otherDep) {}];
         }
       ]);
     }));


### PR DESCRIPTION
Hi, Brian,

This pull request annotates `this.$get = function(dep)` in providers (#31). From the test, it transforms:

``` javascript
angular.module('myMod', []).
  provider('myService', function (dep) {
    this.$get = function(otherDep) {};
  });
```

into this:

``` javascript
angular.module('myMod', []).provider('myService', [
  'dep',
  function (dep) {
    this.$get = ['otherDep', function(otherDep) {}];
  }
]);
```

It's based of the DDO annotation code in `lib/annotate-ast.js`. I've also included some refactoring in that file that extracts repeated code from inside the final `deepApply`s into a function `annotateInjectables` (I'll let you decide on a decent name :) that takes the argument usually named `originalFn` and returns the `ArrayExpression` it should be replaced with (or else returns `originalFn` if nothing is to be annotated).
