### PR TITLE
Fix annotating $get in object-based PDO on module references

### DIFF
--- a/lib/annotate-injectable.js
+++ b/lib/annotate-injectable.js
@@ -3,7 +3,7 @@
 // return an AST chunk representing an annotation array
 var annotateInjectable = module.exports = function (originalFn) {
   // if there's nothing to inject, don't annotate
-  if (originalFn.params.length === 0) {
+  if (!originalFn.params || originalFn.params.length === 0) {
     return originalFn;
   }
 

--- a/signatures/simple.js
+++ b/signatures/simple.js
@@ -49,6 +49,26 @@ module.exports = [
     },
     "property": {
       "type": "Identifier",
+      "name": "provider"
+    }
+  },
+  "arguments": [
+    {},
+    {
+      "type": "ObjectExpression"
+    }
+  ]
+},
+
+{
+  "type": "CallExpression",
+  "callee": {
+    "type": "MemberExpression",
+    "object": {
+      "ngModule": true
+    },
+    "property": {
+      "type": "Identifier",
       "name": /^(config|run)$/
     }
   },

--- a/test/reference.js
+++ b/test/reference.js
@@ -52,6 +52,22 @@ describe('annotate', function () {
     }));
   });
 
+  it('should annotate object-defined providers on referenced modules', function () {
+    var annotated = annotate(function () {
+      var myMod;
+      myMod = angular.module('myMod', []);
+      myMod.provider('MyService', { $get: function(service) {} });
+    });
+
+    annotated.should.equal(stringifyFunctionBody(function () {
+      var myMod;
+      myMod = angular.module('myMod', []);
+      myMod.provider('MyService', {
+        $get: ['service', function(service) {}]
+      });
+    }));
+  });
+
   // TODO: lol commenting out test cases
   /*
   it('should annotate declarations on referenced modules ad infinitum', function () {


### PR DESCRIPTION
Oops! #31 now works for the following case:

``` javascript
angular.module('myApp').provider('MyService', {
  $get: function($window) {}
});
```

but not for this case:

``` javascript
var app = angular.module('myApp');
app.provider('MyService', {
  $get: function($window) {}
});
```

This is because [`signatures/simple.js` requires that the argument be a `FunctionExpression`](https://github.com/btford/ngmin/blob/44f85a8472f711497b24f09585680d7ff4f7f6e8/signatures/simple.js#L38) in order for the module to be marked by `markASTModules`; however, removing the requirement caused `annotateInjectable` to fail because it assumes that anything sent to it was matched by the signature and thus has parameters (e.g. is a `FunctionExpression`) as well.

This pull request does two things:
1. Adds a signature to `simple.js` that allows for matching a `provider` call with an object as the parameter, and
2. Modifies `annotateInjectable` to ensure that `originalFn` even has params before checking their length.

There are probably a couple better ways to go about these checks; let me know if you'd like me to change anything.
