### PR TITLE
+ licence: MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,6 @@ someModule.factory('myFactory', ['myService', function (a) {
 ```
 
 Writing the "minifier-safe" version by hand is kind of annoying because you have to keep both the array of dependency names and function parameters in sync.
+
+## Licence
+MIT


### PR DESCRIPTION
Listing license in the most often human-read `README.md` is normative.  Though [Github expects a `LICENSE.txt`](https://help.github.com/articles/open-source-licensing), it is rarely enforced.
ref: #47
