### PR TITLE
Fixes #19 - Add support for source-map generation

### DIFF
--- a/bin/ngmin
+++ b/bin/ngmin
@@ -7,12 +7,21 @@ var program = require('commander'),
 program
   .version(require('../package.json').version)
   .usage('<infile> <outfile>')
+  .option('|--source-map <path>', "Specify an output file where to generate source map.", null)
+  .option('|--source-map-root <path>', "The path to the original source to be included in the source map.", null)
+  .option('|--in-source-map <path>', "Input source map, useful if you're compressing JS that was generated from some other original code.", null) 
   .parse(process.argv);
 
 if (program.args.length !== 0 && program.args.length !== 2) {
   console.error('ngmin should be called with an input and output file, or no arguments if using stdio');
   process.exit(1);
 }
+
+var options = {
+  sourceMap: program.sourceMap,
+  sourceMapRoot: program.sourceMapRoot,
+  sourceMapIn: program.inSourceMap
+};
 
 if (program.args.length === 2) {
   var infile = program.args[0];
@@ -24,15 +33,22 @@ if (program.args.length === 2) {
     console.error('Error opening: ' + infile);
     process.exit(1);
   }
-  var generatedCode = ngmin.annotate(content);
+  var generated = ngmin.annotate(content, options);
 
   try {
-    fs.writeFileSync(outfile, generatedCode);
+    fs.writeFileSync(outfile, generated.code);
   } catch (e) {
     console.error('Error writing to: ' + outfile);
     process.exit(1);
   }
-
+  if (generated.map) {
+    try {
+      fs.writeFileSync(options.sourceMap, generated.map);
+    } catch (e) {
+      console.error('Error writing to: ' + options.sourceMap);
+      process.exit(1);
+    }
+  }
 } else {
   // else use stdio
   var buffer = '';
@@ -45,6 +61,15 @@ if (program.args.length === 2) {
   });
 
   process.stdin.on('end', function() {
-    process.stdout.write(ngmin.annotate(buffer));
+    var generated = ngmin.annotate(buffer, options);
+    process.stdout.write(generated.code);
+    if (generated.map) {
+      try {
+        fs.writeFileSync(options.sourceMap, generated.map);
+      } catch (e) {
+        console.error('Error writing to: ' + options.sourceMap);
+        process.exit(1);
+      }
+    }
   });
 }

--- a/bin/ngmin
+++ b/bin/ngmin
@@ -26,6 +26,7 @@ var options = {
 if (program.args.length === 2) {
   var infile = program.args[0];
   var outfile = program.args[1];
+  options.sourceFile = infile;
 
   try {
     var content = fs.readFileSync(infile, 'utf-8');
@@ -36,6 +37,9 @@ if (program.args.length === 2) {
   var generated = ngmin.annotate(content, options);
 
   try {
+    if (generated.map) {
+      generated.code += '\n\n//# sourceMappingURL='+options.sourceMap+'\n';
+    }
     fs.writeFileSync(outfile, generated.code);
   } catch (e) {
     console.error('Error writing to: ' + outfile);
@@ -62,6 +66,9 @@ if (program.args.length === 2) {
 
   process.stdin.on('end', function() {
     var generated = ngmin.annotate(buffer, options);
+    if (generated.map) {
+      generated.code += '\n\n//# sourceMappingURL='+options.sourceMap+'\n';
+    }
     process.stdout.write(generated.code);
     if (generated.map) {
       try {

--- a/main.js
+++ b/main.js
@@ -1,15 +1,21 @@
 
 var esprima = require('esprima'),
   escodegen = require('escodegen'),
-  astral = require('astral')();
+  astral = require('astral')(),
+  sourceMap = require('source-map');
 
 // register angular annotator in astral
 require('astral-angular-annotate')(astral);
 
-var annotate = exports.annotate = function (inputCode) {
+var annotate = exports.annotate = function (inputCode, options) {
+  options = options || {};
+  options.sourceMap = options.sourceMap || null;
+  options.sourceMapRoot = options.sourceMapRoot || null;
+  options.sourceMapIn = options.sourceMapIn || null;
 
   var ast = esprima.parse(inputCode, {
-    tolerant: true
+    tolerant: true,
+    loc: true
   });
 
   astral.run(ast);
@@ -19,8 +25,15 @@ var annotate = exports.annotate = function (inputCode) {
       indent: {
         style: '  '
       }
-    }
+    },
+    sourceMap: options.sourceMap,
+    sourceMapRoot: options.sourceMapRoot,
+    sourceMapWithCode: true
   });
+
+  if ('string' === typeof generatedCode) {
+    generatedCode = { code: generatedCode };
+  }
 
   return generatedCode;
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "escodegen": "~0.0.15",
     "esprima": "~1.0.2",
     "commander": "~1.1.1",
-    "clone": "~0.1.6"
+    "clone": "~0.1.6",
+    "source-map": "~0.1.29"
   },
   "devDependencies": {
     "should": "~1.2.1",

--- a/test/chain.js
+++ b/test/chain.js
@@ -25,7 +25,7 @@ describe('annotate', function () {
         service('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         service('myService', ['dep', function (dep) {}]).
         service('MyCtrl', ['$scope', function ($scope) {}]);
@@ -41,7 +41,7 @@ describe('annotate', function () {
         service('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         service('myService', ['dep', function (dep) {}]).
         service('myService2', ['dep', function (dep) {}]).
@@ -59,7 +59,7 @@ describe('annotate', function () {
         service('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         constant('myConstant', 'someConstant').
         constant('otherConstant', 'otherConstant').
@@ -77,7 +77,7 @@ describe('annotate', function () {
         service('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         value('myConstant', 'someConstant').
         value('otherConstant', 'otherConstant').
@@ -95,7 +95,7 @@ describe('annotate', function () {
         service('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         value('myConstant', 'someConstant').
         service('myService1', ['dep', function (dep) {}]).
@@ -111,7 +111,7 @@ describe('annotate', function () {
         factory('b', function ($scope){});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       var mod =  angular.module('chain', []);
       mod.factory('a', ['$scope', function($scope){}]).
         factory('b', ['$scope', function($scope){}]);
@@ -125,7 +125,7 @@ describe('annotate', function () {
       mod.factory('b', function ($scope){});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       var mod =  angular.module('chain', []).
         factory('a', ['$scope', function($scope){}]);
       mod.factory('b', ['$scope', function($scope){}]);

--- a/test/directive.js
+++ b/test/directive.js
@@ -31,7 +31,7 @@ describe('annotate', function () {
         });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         directive('myDir', function () {
           return {
@@ -54,7 +54,7 @@ describe('annotate', function () {
         });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         directive('myDir', ['$window', function ($window) {
           return {

--- a/test/loader.js
+++ b/test/loader.js
@@ -23,7 +23,7 @@ describe('annotate', function () {
       });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       define(["./thing"], function(thing) {
         angular.module('myMod', []).
           controller('MyCtrl', ['$scope', function ($scope) {}]);
@@ -43,7 +43,7 @@ describe('annotate', function () {
 
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       define(["./thing"], function(thing) {
         var myMod = angular.module('myMod', []);
         myMod.controller('MyCtrl', ['$scope', function ($scope) {}]);

--- a/test/reference.js
+++ b/test/reference.js
@@ -24,7 +24,7 @@ describe('annotate', function () {
       myMod.controller('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       var myMod = angular.module('myMod', []);
       myMod.controller('MyCtrl', [
         '$scope',
@@ -41,7 +41,7 @@ describe('annotate', function () {
       myMod.controller('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       var myMod;
       myMod = angular.module('myMod', []);
       myMod.controller('MyCtrl', [
@@ -59,7 +59,7 @@ describe('annotate', function () {
       myMod.provider('MyService', { $get: function(service) {} });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       var myMod;
       myMod = angular.module('myMod', []);
       myMod.provider('MyService', {
@@ -78,7 +78,7 @@ describe('annotate', function () {
       myMod3.controller('MyCtrl', function ($scope) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       var myMod = angular.module('myMod', []);
       var myMod2 = myMod, myMod3;
       myMod3 = myMod2;
@@ -96,7 +96,7 @@ describe('annotate', function () {
       myOtherMod.controller('MyCtrl', function ($scope) {});
     };
     var annotated = annotate(fn);
-    annotated.should.equal(stringifyFunctionBody(fn));
+    annotated.code.should.equal(stringifyFunctionBody(fn));
   });
 
 

--- a/test/route-provider.js
+++ b/test/route-provider.js
@@ -33,7 +33,7 @@ describe('annotate', function () {
         });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         config(['$routeProvider', function ($routeProvider) {
           $routeProvider.when('path', {
@@ -64,7 +64,7 @@ describe('annotate', function () {
         });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         config(['$routeProvider', function ($routeProvider) {
           $routeProvider.

--- a/test/simple.js
+++ b/test/simple.js
@@ -25,7 +25,7 @@ describe('annotate', function () {
         });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).controller('MyCtrl', [
         '$scope',
         function ($scope) {
@@ -47,7 +47,7 @@ describe('annotate', function () {
         });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).directive('myDirective', [
         '$rootScope',
         function ($rootScope) {
@@ -67,7 +67,7 @@ describe('annotate', function () {
         filter('myFilter', function (dep) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).filter('myFilter', [
         'dep',
         function (dep) {
@@ -83,7 +83,7 @@ describe('annotate', function () {
         service('myService', function (dep) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).service('myService', [
         'dep',
         function (dep) {
@@ -99,7 +99,7 @@ describe('annotate', function () {
         controller('factory', function (dep) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).controller('factory', [
         'dep',
         function (dep) {
@@ -115,7 +115,7 @@ describe('annotate', function () {
         decorator('myService', function (dep) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).decorator('myService', [
         'dep',
         function (dep) {
@@ -131,7 +131,7 @@ describe('annotate', function () {
         config(function (dep) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).config([
         'dep',
         function (dep) {
@@ -147,7 +147,7 @@ describe('annotate', function () {
         run(function (dep) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).run([
         'dep',
         function (dep) {
@@ -165,7 +165,7 @@ describe('annotate', function () {
         });
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).provider('myService', [
         'dep',
         function (dep) {
@@ -184,7 +184,7 @@ describe('annotate', function () {
         })
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []).
         provider('myService', {
           $get: ['otherDep', function(otherDep) {}]
@@ -200,7 +200,7 @@ describe('annotate', function () {
         provider('myService', function (dep) {});
     });
 
-    annotated.should.equal(stringifyFunctionBody(function () {
+    annotated.code.should.equal(stringifyFunctionBody(function () {
       angular.module('myMod', []);
       angular.module('myMod').provider('myService', [
         'dep',
@@ -218,7 +218,7 @@ describe('annotate', function () {
     };
     var annotated = annotate(fn);
 
-    annotated.should.equal(stringifyFunctionBody(fn));
+    annotated.code.should.equal(stringifyFunctionBody(fn));
   });
 
 
@@ -228,7 +228,7 @@ describe('annotate', function () {
     };
 
     var annotated = annotate(fn);
-    annotated.should.equal(stringifyFunctionBody(fn));
+    annotated.code.should.equal(stringifyFunctionBody(fn));
   });
 
 
@@ -238,7 +238,7 @@ describe('annotate', function () {
     };
 
     var annotated = annotate(fn);
-    annotated.should.equal(stringifyFunctionBody(fn));
+    annotated.code.should.equal(stringifyFunctionBody(fn));
   });
 
 });


### PR DESCRIPTION
The generated sourcemap is not very helpful as of yet, but I'm working on that. I think this is probably a better solution than the alternative method attempted earlier :)

The `astral-angular-annotate` module will need to be updated to update the locations of items, I think. But it's sort of difficult to work out how it's intended to actually work.

I don't know how this will work with source-map chaining as of yet, that is a more involved test, I'll do more of that once it's a bit further along I suppose.
