### PR TITLE
Do not remove comments from annotated source code.

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,8 +9,13 @@ require('astral-angular-annotate')(astral);
 var annotate = exports.annotate = function (inputCode) {
 
   var ast = esprima.parse(inputCode, {
-    tolerant: true
+    tolerant: true,
+    comment: true,
+    range: true,
+    tokens: true
   });
+  // TODO: unstable API, see https://github.com/Constellation/escodegen/issues/10
+  ast = escodegen.attachComments(ast, ast.comments, ast.tokens);
 
   astral.run(ast);
 
@@ -19,7 +24,8 @@ var annotate = exports.annotate = function (inputCode) {
       indent: {
         style: '  '
       }
-    }
+    },
+    comment: true
   });
 
   return generatedCode;

--- a/test/reference.js
+++ b/test/reference.js
@@ -99,5 +99,22 @@ describe('annotate', function () {
     annotated.should.equal(stringifyFunctionBody(fn));
   });
 
+  it('should keep comments', function() {
+    var annotated = annotate(function () {
+      var myMod = angular.module('myMod', []);
+      /*! license */
+      myMod.controller('MyCtrl', function ($scope) {});
+    });
+
+    annotated.should.equal(stringifyFunctionBody(function () {
+      var myMod = angular.module('myMod', []);
+      /*! license */
+      myMod.controller('MyCtrl', [
+        '$scope',
+        function ($scope) {
+        }
+      ]);
+    }));
+  });
 
 });

--- a/test/util.js
+++ b/test/util.js
@@ -18,16 +18,23 @@ exports.stringifyFunctionBody = function (fn) {
     replace(trailingBrace, '');
 
   // then normalize with esprima/escodegen
-  out = escodegen.generate(
-    esprima.parse(out, {
-      tolerant: true
-    }), {
-      format: {
-        indent: {
-          style: '  '
-        }
+  var ast = esprima.parse(out, {
+    tolerant: true,
+    comment: true,
+    range: true,
+    tokens: true
+  });
+  // TODO: unstable API, see https://github.com/Constellation/escodegen/issues/10
+  ast = escodegen.attachComments(ast, ast.comments, ast.tokens);
+
+  out = escodegen.generate(ast, {
+    format: {
+      indent: {
+        style: '  '
       }
-    });
+    },
+    comment: true
+  });
 
   return out;
 };


### PR DESCRIPTION
In my project I need to keep some license comments in the optimized output. I use `uglify` with `preserveComments` set to `some` to achieve this. The problem is that `ngmin` removes all comments before `uglify` has a chance to do anything.

This pull request fixes `ngmin` to keep comments in annotated code. The solution is not ideal as it depends on the experimental API in `esprima` and `escodegen` ([see this issue](https://github.com/Constellation/escodegen/issues/10)), so it's likely to break in the future.

I'm not sure whether it is a good idea to merge this in its current form. In the meantime I have published this fix as new package in npm: [`grunt-ngmin-with-comments`](https://npmjs.org/package/grunt-ngmin-with-comments) and [`ngmin-with-comments`](https://npmjs.org/package/ngmin-with-comments)
