### PR TITLE
Add plug-able annotation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,5 +161,24 @@ someModule.factory('myFactory', ['myService', function (a) {
 
 Writing the "minifier-safe" version by hand is kind of annoying because you have to keep both the array of dependency names and function parameters in sync.
 
+## Plugin system
+
+If a library is not supported by ngmin it is possible to extend the annotation system by using annotation modules. These modules must be prefixed with `astral-angular-annotate-`. When installing such a module (preferred as `devDependency`) ngmin with automatically pick up the module and apply them to your code.
+
+### Plugin creation
+
+If your library is not supported by any annotation module you can create your own one. For usage you need to make sure your plugin package name is prefixed with `astral-angular-annotate-` and exports an function with the following signature:
+
+```
+module.exports = function (astral) {
+  // Your annotation code
+};
+```
+
+For further information see the following annotation modules:
+
+ * [Astral Angular Annotator](https://github.com/btford/astral-angular-annotate)
+ * [Angular ngRoute Extension](https://github.com/werk85/astral-angular-annotate-ng-route)
+
 ## License
 MIT

--- a/main.js
+++ b/main.js
@@ -1,12 +1,34 @@
 
 var esprima = require('esprima'),
   escodegen = require('escodegen'),
+  findup = require('findup-sync'),
+  globule = require('globule'),
   astral = require('astral')();
 
-// register angular annotator in astral
-require('astral-angular-annotate')(astral);
+function arrayify(el) {
+  return Array.isArray(el) ? el : [el];
+}
 
-var annotate = exports.annotate = function (inputCode) {
+var annotate = exports.annotate = function (inputCode, options) {
+  options = options || {};
+
+  var pattern = arrayify(options.pattern || ['astral-angular-annotate-*']);
+  var config = options.config || findup('package.json');
+  var scope = arrayify(options.scope || ['dependencies', 'devDependencies', 'peerDependencies']);
+
+  if (typeof config === 'string') {
+    config = require(config);
+  }
+
+  var names = scope.reduce(function (result, prop) {
+    return result.concat(Object.keys(config[prop] || {}));
+  }, []);
+
+  // register angular annotator in astral
+  require('astral-angular-annotate')(astral);
+  globule.match(pattern, names).forEach(function (annotation) {
+    require(annotation)(astral);
+  });
 
   var ast = esprima.parse(inputCode, {
     tolerant: true,

--- a/package.json
+++ b/package.json
@@ -11,9 +11,12 @@
     "escodegen": "~0.0.15",
     "esprima": "~1.0.2",
     "commander": "~1.1.1",
-    "clone": "~0.1.6"
+    "clone": "~0.1.6",
+    "findup-sync": "~0.1.2",
+    "globule": "~0.1.0"
   },
   "devDependencies": {
+    "astral-angular-annotate-ng-route": "git@github.com:werk85/astral-angular-annotate-ng-route.git",
     "should": "~1.2.1",
     "mocha": "~1.5.0"
   },

--- a/test/route-provider.js
+++ b/test/route-provider.js
@@ -28,6 +28,11 @@ describe('annotate', function () {
           $routeProvider.when('path', {
             controller: function ($scope) {
               $scope.works = true;
+            },
+            resolve: {
+              data: function ($http) {
+                return $http.get('test.json');
+              }
             }
           });
         });
@@ -39,12 +44,16 @@ describe('annotate', function () {
           $routeProvider.when('path', {
             controller: ['$scope', function ($scope) {
               $scope.works = true;
-            }]
+            }],
+            resolve: {
+              data: ['$http', function ($http) {
+                return $http.get('test.json');
+              }]
+            }
           });
         }]);
     }));
   });
-
 
   it('should annotate chained $routeProvider.when()', function () {
     var annotated = annotate(function () {


### PR DESCRIPTION
I add the possibility to extend ngmin with annotation packages which are prefixed with `astral-angular-annotate-`. One extension can be found here https://github.com/werk85/astral-angular-annotate-ng-route. This adds `resolve` support to the ngRoute annotations.

The target of this pull request is to make ngmin more open and allow external angular libraries to provide their own annotations. This would resolve many issues here in the issue tracker. Also would it be possible for the angular team to split up their annotations in separate packages.

This is not finished yet, but it would be nice to get some feedback.

Thanks to @sindresorhus who inspired me to this implementation.
