### PR TITLE
Add ngmin as available for Clojure Ring via optimus-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,15 @@ npm install -g ngmin
 ## Grunt Task
 `ngmin` is available as a [Grunt](http://gruntjs.com/) task as [`grunt-ngmin`](https://github.com/btford/grunt-ngmin).
 
-## Rails (Asset Pipeline)
+## Asset Pipelines
+
+### Ruby on Rails
 
 `ngmin` is available for Rails via [`ngmin-rails`](http://rubygems.org/gems/ngmin-rails).
+
+### Clojure Ring
+
+`ngmin` is available for Clojure Ring via [`optimus-angular`](https://github.com/magnars/optimus-angular) as an [`Optimus`](https://github.com/magnars/optimus) asset middleware.
 
 ## CLI Usage
 


### PR DESCRIPTION
I thought you might like to know that ngmin is integrated in an asset pipeline for Clojure. :-)

Then I noticed you had Rails listed in the readme.

I wasn't sure if you're interested in enumerating ways of using ngmin for other platforms, but if you are - here's a pull request to that effect for Clojure.
